### PR TITLE
add: jpa auditing 클래스 추가

### DIFF
--- a/src/main/java/com/bluesky/erp/common/auditing/BaseTimeAndModifierEntity.java
+++ b/src/main/java/com/bluesky/erp/common/auditing/BaseTimeAndModifierEntity.java
@@ -1,0 +1,20 @@
+package com.bluesky.erp.common.auditing;
+
+import jakarta.persistence.Column;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class BaseTimeAndModifierEntity extends BaseTimeEntity {
+
+    @CreatedBy
+    @Column(name="created_by", updatable = false)
+    private LocalDateTime createdBy;
+
+    @LastModifiedBy
+    @Column(name="modified_by")
+    private LocalDateTime modifiedBy;
+}

--- a/src/main/java/com/bluesky/erp/common/auditing/BaseTimeEntity.java
+++ b/src/main/java/com/bluesky/erp/common/auditing/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.bluesky.erp.common.auditing;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_date", updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "modified_date")
+    private LocalDateTime modifiedDate;
+}


### PR DESCRIPTION
생성일, 수정일은 모든 엔티티에 존재하므로 BaseTimeEntity는 auditing 클래스 상속 계층의 가장 위에 위치합니다.
                                                                                                                                                                                                                                                                                                                                                                                               
1. BaseTimeEntity 는 생성일, 수정일만 auditing 하는 경우 상속받습니다.
2. BaseTimeAndModifierEntity 는 BaseTimeEntity 를 상속받고 있으며 생성자, 수정자 auditing 이 추가로 필요할 경우 상속받으면 됩니다.